### PR TITLE
k6 v0.42.0 updates - helper scripts (3/5)

### DIFF
--- a/k6bench.gnuplot
+++ b/k6bench.gnuplot
@@ -1,0 +1,28 @@
+set datafile separator ','
+set terminal pngcairo background rgb 'white' linewidth 4 size 1200,600 enhanced font 'Arial,16'
+set bmargin at screen 130.0/600
+set rmargin at screen 1080.0/1200
+set output sprintf('%s-%s.png', ec2instance, script)
+
+set title sprintf('k6 %s / EC2 %s / %s', k6version, ec2instance, script) font 'Arial Bold,20'
+set key at graph 0.6, 0.3 autotitle columnhead
+
+set border 31 lw 0.5
+set style data lines
+set style line 100 lt 1 lc rgb "grey" lw 0.5 # linestyle for the grid
+set grid ls 100
+
+set xtics 30
+set xlabel 'Time (M:S)'
+set xdata time
+set format x '%M:%S'
+set xtics rotate
+set y2tics           # enable second axis
+set ytics nomirror   # dont show the tics on that side
+set y2range [0:]     # start from 0
+set y2label "CPU (%)"
+
+plot sprintf('%s-%s.csv', ec2instance, script) using ($1):2 axis x1y2 lc rgb '#00d8bfd8', \
+     '' using ($1):($3 / 1000) title 'RAM (MB)', \
+     '' using ($1):4, \
+     '' using ($1):5

--- a/k6bench.sh
+++ b/k6bench.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# External dependencies:
+# - https://www.selenic.com/smem/
+# - https://stedolan.github.io/jq/
+set -eEuo pipefail
+
+trap 'kill 0' exit INT
+
+# 5s is the default interval between samples.
+# Note that this might be greater if either smem or the k6 API takes more time
+# than this to return a response.
+sint="${K6_BENCH_SAMPLE_INTERVAL:-5}"
+
+k6 run "$@" >k6out.txt 2>&1 &
+pid="$!"
+
+echo '"Time (s)","CPU (%)","RAM (kB)","VUs","RPS"'
+while true; do
+  cpu=$(top -b -n 2 -d "$sint" -p "$pid" | tail -1 | awk '{print $9}')
+  mem=$(smem -H -U "$USER" -c 'pid pss' -P 'k6 run' | grep "$pid" | awk '{ print $NF }')
+  vus=$({ curl -fsSL http://localhost:6565/v1/metrics/vus 2>/dev/null || echo '{}'
+        } | jq '.data.attributes.sample.value // 0')
+  rps=$({ curl -fsSL http://localhost:6565/v1/metrics/http_reqs 2>/dev/null || echo '{}'
+        } | jq '.data.attributes.sample.rate // 0')
+  etimes=$(ps -p "$pid" --no-headers -o etimes | awk '{ print $1 }')
+  echo "${etimes},${cpu},${mem},${vus},${rps}"
+done

--- a/k6bench.sh
+++ b/k6bench.sh
@@ -4,7 +4,19 @@
 # - https://stedolan.github.io/jq/
 set -eEuo pipefail
 
-trap 'kill 0' exit INT
+trap 'cleanup; exit 0' EXIT
+trap 'trap - INT; cleanup; kill -INT $$' INT
+trap 'trap - TERM; cleanup; kill -TERM $$' TERM
+
+# Create temp files to store the output of each collection command.
+cpuf=$(mktemp)
+memf=$(mktemp)
+vusf=$(mktemp)
+rpsf=$(mktemp)
+
+cleanup() {
+  rm -f "$cpuf" "$memf" "$vusf" "$rpsf"
+}
 
 # 5s is the default interval between samples.
 # Note that this might be greater if either smem or the k6 API takes more time
@@ -12,16 +24,25 @@ trap 'kill 0' exit INT
 sint="${K6_BENCH_SAMPLE_INTERVAL:-5}"
 
 k6 run "$@" >k6out.txt 2>&1 &
-pid="$!"
+k6pid="$!"
+
+# Run the collection processes in parallel to avoid blocking.
+# For details see https://stackoverflow.com/a/68316571
 
 echo '"Time (s)","CPU (%)","RAM (kB)","VUs","RPS"'
 while true; do
-  cpu=$(top -b -n 2 -d "$sint" -p "$pid" | tail -1 | awk '{print $9}')
-  mem=$(smem -H -U "$USER" -c 'pid pss' -P 'k6 run' | grep "$pid" | awk '{ print $NF }')
-  vus=$({ curl -fsSL http://localhost:6565/v1/metrics/vus 2>/dev/null || echo '{}'
-        } | jq '.data.attributes.sample.value // 0')
-  rps=$({ curl -fsSL http://localhost:6565/v1/metrics/http_reqs 2>/dev/null || echo '{}'
-        } | jq '.data.attributes.sample.rate // 0')
-  etimes=$(ps -p "$pid" --no-headers -o etimes | awk '{ print $1 }')
-  echo "${etimes},${cpu},${mem},${vus},${rps}"
+  etimes=$(ps -p "$k6pid" --no-headers -o etimes | awk '{ print $1 }')
+  pids=()
+  { exec >"$cpuf"; top -b -n 2 -d "$sint" -p "$k6pid" | tail -1 | awk '{print $9}'; } &
+  pids+=($!)
+  { exec >"$memf"; smem -H -U "$USER" -c 'pid pss' -P 'k6 run' | grep "$k6pid" | awk '{ print $NF }'; } &
+  pids+=($!)
+  { exec >"$vusf"; { curl -fsSL http://localhost:6565/v1/metrics/vus 2>/dev/null || echo '{}'
+    } | jq '.data.attributes.sample.value // 0'; } &
+  pids+=($!)
+  { exec >"$rpsf"; { curl -fsSL http://localhost:6565/v1/metrics/http_reqs 2>/dev/null || echo '{}'
+    } | jq '.data.attributes.sample.rate // 0'; } &
+  pids+=($!)
+  wait "${pids[@]}"
+  echo "${etimes},$(cat "$cpuf"),$(cat "$memf"),$(cat "$vusf"),$(cat "$rpsf")"
 done

--- a/k6bench.sh
+++ b/k6bench.sh
@@ -33,9 +33,11 @@ echo '"Time (s)","CPU (%)","RAM (kB)","VUs","RPS"'
 while true; do
   etimes=$(ps -p "$k6pid" --no-headers -o etimes | awk '{ print $1 }')
   pids=()
-  { exec >"$cpuf"; top -b -n 2 -d "$sint" -p "$k6pid" | tail -1 | awk '{print $9}'; } &
+  { exec >"$cpuf"; top -b -n 2 -d "$sint" -p "$k6pid" | {
+      grep "$k6pid" || echo; } | tail -1 | awk '{print (NF>0 ? $9 : "0")}'; } &
   pids+=($!)
-  { exec >"$memf"; smem -H -U "$USER" -c 'pid pss' -P 'k6 run' | grep "$k6pid" | awk '{ print $NF }'; } &
+  { exec >"$memf"; smem -H -U "$USER" -c 'pid pss' -P 'k6 run' | {
+      grep "$k6pid" || echo 0; } | awk '{ print $NF }'; } &
   pids+=($!)
   { exec >"$vusf"; { curl -fsSL http://localhost:6565/v1/metrics/vus 2>/dev/null || echo '{}'
     } | jq '.data.attributes.sample.value // 0'; } &


### PR DESCRIPTION
This is PR 3/5, part of [updating the "Running large tests" article](https://github.com/grafana/k6-docs/issues/208) and running benchmarks on k6 v0.42.0.

These changes add a couple of helper scripts:
- `k6bench.sh`: runs k6 in the background, while collecting performance metrics (CPU/RAM usage of the k6 process, `vus` and `http_reqs` metrics from the k6 HTTP API), and writing them to stdout in CSV format.
  The polling period is configurable with the `K6_BENCH_SAMPLE_INTERVAL` env var, and defaults to 5s.
  Example command:
  ```shell
  ./k6bench.sh --vus=100 --duration=10s scripts/website.js
  ```
  It has two external dependencies: [smem](https://www.selenic.com/smem/) and [jq](https://stedolan.github.io/jq/).
- `k6bench.gnuplot`: a gnuplot 5.4 script to generate graphs from the CSV output from the `k6bench.sh` script.
  Example command:
  ```shell
  gnuplot -e 'k6version="v0.42.0"; ec2instance="m5.large"; script="website.js-10s"' ../../k6bench.gnuplot
  ```
  This will generate a `m5.large-website.js-10s.png` in the current directory.

More command examples and outputs of these scripts can be seen in #24.

The idea is that these scripts will be run in CI and the entire benchmarking process will be automated. I didn't want to rely on k6 Cloud for metric aggregation and graphing for several reasons:
- Using `--out cloud` consumes considerable network bandwidth, which could affect some of the network tests, CPU usage or even RPS.
- The k6 Cloud has no way of measuring CPU and memory usage of the k6 process itself. Not until [k6 is able to emit these metrics internally](https://github.com/grafana/k6/issues/888), which I still think is the wrong thing to do, considering how many trivial ways it's possible to do this externally.
- It's best to keep the benchmarking offline without depending on a separate service so that users can run the same scripts we do and verify the results independently of any 3rd party. We could possibly push the results to Grafana to get nicer and interactive graphs, but the gnuplot graphs are not that bad. :)

I'm open to any improvement suggestions to this process, but so far I think it's the best approach.

PR order: #21 -> #22 -> #23 -> [#24](https://github.com/grafana/k6-hardware-benchmark/pull/24) -> [#25](https://github.com/grafana/k6-hardware-benchmark/pull/25) (review and merge in reverse)